### PR TITLE
TeukolskyMode numerical evaluation

### DIFF
--- a/Kernel/TeukolskyMode.m
+++ b/Kernel/TeukolskyMode.m
@@ -201,6 +201,26 @@ Derivative[n_][TeukolskyMode[assoc_]][r:(_?NumericQ|{_?NumericQ..})] :=
   ];
 
 
+(* ::Subsection::Closed:: *)
+(*Numerical Evaluation using extended homogeneous solutions*)
+
+
+TeukolskyMode[assoc_]["ExtendedHomogeneous" -> "\[ScriptCapitalH]"][r:(_?NumericQ|{_?NumericQ..})] :=
+  assoc["Amplitudes"]["\[ScriptCapitalH]"]assoc["RadialFunctions"]["In"][r];
+
+
+Derivative[n_][TeukolskyMode[assoc_]["ExtendedHomogeneous" -> "\[ScriptCapitalH]"]][r:(_?NumericQ|{_?NumericQ..})] :=
+  assoc["Amplitudes"]["\[ScriptCapitalH]"]Derivative[n][assoc["RadialFunctions"]["In"]][r];
+
+
+TeukolskyMode[assoc_]["ExtendedHomogeneous" -> "\[ScriptCapitalI]"][r:(_?NumericQ|{_?NumericQ..})] :=
+  assoc["Amplitudes"]["\[ScriptCapitalI]"]assoc["RadialFunctions"]["Up"][r];
+
+
+Derivative[n_][TeukolskyMode[assoc_]["ExtendedHomogeneous" -> "\[ScriptCapitalI]"]][r:(_?NumericQ|{_?NumericQ..})] :=
+  assoc["Amplitudes"]["\[ScriptCapitalI]"]Derivative[n][assoc["RadialFunctions"]["Up"]][r];
+
+
 (* ::Section::Closed:: *)
 (*Fluxes*)
 

--- a/Kernel/TeukolskyMode.m
+++ b/Kernel/TeukolskyMode.m
@@ -99,7 +99,9 @@ TeukolskyPointParticleMode[s_Integer, l_Integer, m_Integer, n_Integer, k_Integer
     rmax = p/(1-e);
     R = TeukolskyRadial[s, l, m, a, \[Omega], Method->{"NumericalIntegration","Domain"-> {"In"->{rmin,rmax}, "Up"->{rmin,rmax}}},
         "Amplitudes" -> <|"In"-> R["In"]["UnscaledAmplitudes"], "Up"-> R["Up"]["UnscaledAmplitudes"]|>,
-        "RenormalizedAngularMomentum"-> R["In"]["RenormalizedAngularMomentum"], "Eigenvalue" -> R["In"]["Eigenvalue"]]
+        "RenormalizedAngularMomentum"-> R["In"]["RenormalizedAngularMomentum"], "Eigenvalue" -> R["In"]["Eigenvalue"]];
+  ,
+    rmin = rmax = p;
   ];
   
   S = SpinWeightedSpheroidalHarmonicS[s, l, m, a \[Omega]];
@@ -119,6 +121,8 @@ TeukolskyPointParticleMode[s_Integer, l_Integer, m_Integer, n_Integer, k_Integer
                e == 0, {"PointParticleSpherical", "Radius" -> p, "Inclination" -> x},
                Abs[x] == 1, {"PointParticleEccentric", "Semi-latus Rectum" -> p, "Eccentricity" -> e},
                True, {"PointParticleGeneric", "Semi-latus Rectum" -> p, "Eccentricity" -> e , "Inclination" -> x}],
+ 		    "rmin" -> rmin,
+ 		    "rmax" -> rmax,
 		     "RadialFunctions" -> Ruser,
 		     "AngularFunction" -> S,
 		     "Amplitudes" -> Z
@@ -173,10 +177,28 @@ TeukolskyMode[assoc_]["Fluxes"] := <|"Energy" -> TeukolskyMode[assoc]["EnergyFlu
 TeukolskyMode[assoc_]["AngularMomentumFlux"] := AngularMomentumFlux[TeukolskyMode[assoc]];
 
 
-TeukolskyMode[assoc_][string_] := assoc[string];
+TeukolskyMode[assoc_][key_String] /; KeyExistsQ[assoc, key] := assoc[key];
 
 
 Keys[m_TeukolskyMode] ^:= Join[Keys[m[[1]]], {"Fluxes", "EnergyFlux", "AngularMomentumFlux"}];
+
+
+(* ::Subsection::Closed:: *)
+(*Numerical Evaluation*)
+
+
+TeukolskyMode[assoc_][r:(_?NumericQ|{_?NumericQ..})] :=
+  Piecewise[{{assoc["Amplitudes"]["\[ScriptCapitalH]"]assoc["RadialFunctions"]["In"][r], r < assoc["rmin"]},
+             {assoc["Amplitudes"]["\[ScriptCapitalI]"]assoc["RadialFunctions"]["Up"][r], r > assoc["rmax"]}},
+            Indeterminate
+  ];
+
+
+Derivative[n_][TeukolskyMode[assoc_]][r:(_?NumericQ|{_?NumericQ..})] :=
+  Piecewise[{{assoc["Amplitudes"]["\[ScriptCapitalH]"]Derivative[n][assoc["RadialFunctions"]["In"]][r], r < assoc["rmin"]},
+             {assoc["Amplitudes"]["\[ScriptCapitalI]"]Derivative[n][assoc["RadialFunctions"]["Up"]][r], r > assoc["rmax"]}},
+            Indeterminate
+  ];
 
 
 (* ::Section::Closed:: *)


### PR DESCRIPTION
This adds support for numerical evaluation of a TeukolskyMode. Specifying a numerical value for r yields the particular solution outside of the libration region and Indeterminate inside. There is also the option to evaluate the extended homogeneous solutions by passing an option. Some example uses are given below
```Mathematica
orbit = KerrGeoOrbit[0.1, 10.0, 0.1, 1];
Psi = TeukolskyPointParticleMode[0, 2, 2, 0, 0, orbit];

{Psi[10], Psi'[10], Psi[11], Psi'[11],
 Psi["ExtendedHomogeneous"-> "\[ScriptCapitalH]"][10],
 Psi["ExtendedHomogeneous"-> "\[ScriptCapitalH]"]'[10],
 Psi["ExtendedHomogeneous"-> "\[ScriptCapitalI]"][10],
 Psi["ExtendedHomogeneous"-> "\[ScriptCapitalI]"]'[10]}
```
This produces
```Mathematica
{Indeterminate, Indeterminate, -0.000395371 - 0.000121429 I, 0.000100224 + 0.0000300154 I,
 -10.6123 + 3.19168 I,
 -2.27986 + 0.685672 I,
 -0.000697364 - 0.000212233 I,
 0.000221888 + 0.000066877 I}
```
The commit also adds two new Keys: "rmin" and "rmax" representing the extent of the libration region.