### PR TITLE
Teukolsky mode domain

### DIFF
--- a/Kernel/TeukolskyMode.m
+++ b/Kernel/TeukolskyMode.m
@@ -64,11 +64,11 @@ SyntaxInformation[TeukolskyPointParticleMode] =
  {"ArgumentsPattern" -> {_, _, _, _, _, _, OptionsPattern[]}};
 
 
-Options[TeukolskyPointParticleMode] = {};
+Options[TeukolskyPointParticleMode] = {"Domain" -> Automatic};
 
 
 TeukolskyPointParticleMode[s_Integer, l_Integer, m_Integer, n_Integer, k_Integer, orbit_KerrGeoOrbitFunction, opts:OptionsPattern[]] /; AllTrue[orbit["Frequencies"], InexactNumberQ] :=
- Module[{source, assoc, Ruser, R, S, \[Omega], \[CapitalOmega]r, \[CapitalOmega]\[Phi], \[CapitalOmega]\[Theta], Z, \[Lambda], rmin, rmax, a, p, e, x},
+ Module[{source, assoc, domain, Ruser, R, S, \[Omega], \[CapitalOmega]r, \[CapitalOmega]\[Phi], \[CapitalOmega]\[Theta], Z, \[Lambda], rmin, rmax, a, p, e, x},
   {a, p, e, x} = orbit /@ {"a", "p", "e", "Inclination"};
 
   If[(s != -2  && s != -1 && s != +1 && s != 0) ||
@@ -93,7 +93,14 @@ TeukolskyPointParticleMode[s_Integer, l_Integer, m_Integer, n_Integer, k_Integer
 
   source = Teukolsky`TeukolskySource`Private`TeukolskyPointParticleSource[s, orbit];
 
-  R = Ruser = TeukolskyRadial[s, l, m, a, \[Omega]];
+  domain = OptionValue["Domain"];
+  If[MatchQ[domain, {_?NumericQ, _?NumericQ}],
+    R = Ruser = TeukolskyRadial[s, l, m, a, \[Omega], Method ->
+      {"NumericalIntegration", "Domain"-> {"In" -> domain, "Up" -> domain}}];
+  ,
+    R = Ruser = TeukolskyRadial[s, l, m, a, \[Omega]];
+  ];
+
   If[e != 0,
     rmin = p/(1+e);
     rmax = p/(1-e);
@@ -123,6 +130,7 @@ TeukolskyPointParticleMode[s_Integer, l_Integer, m_Integer, n_Integer, k_Integer
                True, {"PointParticleGeneric", "Semi-latus Rectum" -> p, "Eccentricity" -> e , "Inclination" -> x}],
  		    "rmin" -> rmin,
  		    "rmax" -> rmax,
+ 		    "Domain" -> domain,
 		     "RadialFunctions" -> Ruser,
 		     "AngularFunction" -> S,
 		     "Amplitudes" -> Z

--- a/Kernel/TeukolskyMode.m
+++ b/Kernel/TeukolskyMode.m
@@ -201,6 +201,26 @@ Derivative[n_][TeukolskyMode[assoc_]][r:(_?NumericQ|{_?NumericQ..})] :=
   ];
 
 
+(* ::Subsection::Closed:: *)
+(*Numerical Evaluation using extended homogeneous solutions*)
+
+
+TeukolskyMode[assoc_]["ExtendedHomogeneous" -> "\[ScriptCapitalH]"][r:(_?NumericQ|{_?NumericQ..})] :=
+  assoc["Amplitudes"]["\[ScriptCapitalH]"]assoc["RadialFunctions"]["In"][r];
+
+
+Derivative[n_][TeukolskyMode[assoc_]["ExtendedHomogeneous" -> "\[ScriptCapitalH]"]][r:(_?NumericQ|{_?NumericQ..})] :=
+  assoc["Amplitudes"]["\[ScriptCapitalH]"]Derivative[n][assoc["RadialFunctions"]["In"]][r];
+
+
+TeukolskyMode[assoc_]["ExtendedHomogeneous" -> "\[ScriptCapitalI]"][r:(_?NumericQ|{_?NumericQ..})] :=
+  assoc["Amplitudes"]["\[ScriptCapitalI]"]assoc["RadialFunctions"]["Up"][r];
+
+
+Derivative[n_][TeukolskyMode[assoc_]["ExtendedHomogeneous" -> "\[ScriptCapitalI]"]][r:(_?NumericQ|{_?NumericQ..})] :=
+  assoc["Amplitudes"]["\[ScriptCapitalI]"]Derivative[n][assoc["RadialFunctions"]["Up"]][r];
+
+
 (* ::Section::Closed:: *)
 (*Fluxes*)
 

--- a/Kernel/TeukolskyMode.m
+++ b/Kernel/TeukolskyMode.m
@@ -99,7 +99,9 @@ TeukolskyPointParticleMode[s_Integer, l_Integer, m_Integer, n_Integer, k_Integer
     rmax = p/(1-e);
     R = TeukolskyRadial[s, l, m, a, \[Omega], Method->{"NumericalIntegration","Domain"-> {"In"->{rmin,rmax}, "Up"->{rmin,rmax}}},
         "Amplitudes" -> <|"In"-> R["In"]["UnscaledAmplitudes"], "Up"-> R["Up"]["UnscaledAmplitudes"]|>,
-        "RenormalizedAngularMomentum"-> R["In"]["RenormalizedAngularMomentum"], "Eigenvalue" -> R["In"]["Eigenvalue"]]
+        "RenormalizedAngularMomentum"-> R["In"]["RenormalizedAngularMomentum"], "Eigenvalue" -> R["In"]["Eigenvalue"]];
+  ,
+    rmin = rmax = p;
   ];
   
   S = SpinWeightedSpheroidalHarmonicS[s, l, m, a \[Omega]];
@@ -119,6 +121,8 @@ TeukolskyPointParticleMode[s_Integer, l_Integer, m_Integer, n_Integer, k_Integer
                e == 0, {"PointParticleSpherical", "Radius" -> p, "Inclination" -> x},
                Abs[x] == 1, {"PointParticleEccentric", "Semi-latus Rectum" -> p, "Eccentricity" -> e},
                True, {"PointParticleGeneric", "Semi-latus Rectum" -> p, "Eccentricity" -> e , "Inclination" -> x}],
+ 		    "rmin" -> rmin,
+ 		    "rmax" -> rmax,
 		     "RadialFunctions" -> Ruser,
 		     "AngularFunction" -> S,
 		     "Amplitudes" -> Z
@@ -173,10 +177,28 @@ TeukolskyMode[assoc_]["Fluxes"] := <|"Energy" -> TeukolskyMode[assoc]["EnergyFlu
 TeukolskyMode[assoc_]["AngularMomentumFlux"] := AngularMomentumFlux[TeukolskyMode[assoc]];
 
 
-TeukolskyMode[assoc_][string_] := assoc[string];
+TeukolskyMode[assoc_][key_String] /; KeyExistsQ[assoc, key] := assoc[key];
 
 
 Keys[m_TeukolskyMode] ^:= Join[Keys[m[[1]]], {"Fluxes", "EnergyFlux", "AngularMomentumFlux"}];
+
+
+(* ::Subsection::Closed:: *)
+(*Numerical Evaluation*)
+
+
+TeukolskyMode[assoc_][r:(_?NumericQ|{_?NumericQ..})] :=
+  Piecewise[{{assoc["Amplitudes"]["\[ScriptCapitalH]"]assoc["RadialFunctions"]["In"][r], r < assoc["rmin"]},
+             {assoc["Amplitudes"]["\[ScriptCapitalI]"]assoc["RadialFunctions"]["Up"][r], r > assoc["rmax"]}},
+            Indeterminate
+  ];
+
+
+Derivative[n_][TeukolskyMode[assoc_]][r:(_?NumericQ|{_?NumericQ..})] :=
+  Piecewise[{{assoc["Amplitudes"]["\[ScriptCapitalH]"]Derivative[n][assoc["RadialFunctions"]["In"]][r], r < assoc["rmin"]},
+             {assoc["Amplitudes"]["\[ScriptCapitalI]"]Derivative[n][assoc["RadialFunctions"]["Up"]][r], r > assoc["rmax"]}},
+            Indeterminate
+  ];
 
 
 (* ::Section::Closed:: *)


### PR DESCRIPTION
This adds a "Domain" option to TeukolskyPointParticleMode, which sets the domain on which the radial functions should be precomputed. This is useful as it makes it much more efficient to evaluate a TeukolskyMode on a set of points.
