### PR TITLE
Make n and k optional for special (circular, spherical, eccentric) orbits

### DIFF
--- a/Kernel/TeukolskyMode.m
+++ b/Kernel/TeukolskyMode.m
@@ -64,7 +64,7 @@ Begin["`Private`"];
 
 
 SyntaxInformation[TeukolskyPointParticleMode] =
- {"ArgumentsPattern" -> {_, _, _, _, _, _, OptionsPattern[]}};
+ {"ArgumentsPattern" -> {_, _, _, _., _., _, OptionsPattern[]}};
 
 
 Options[TeukolskyPointParticleMode] = {"Domain" -> Automatic};
@@ -147,6 +147,31 @@ TeukolskyPointParticleMode[s_Integer, l_Integer, m_Integer, n_Integer, k_Integer
 
   TeukolskyMode[assoc]
 ]
+
+
+(* ::Subsection::Closed:: *)
+(*Special cases*)
+
+
+circularOrbitQ[orbit_KerrGeoOrbitFunction] := orbit["e"] == 0 && Abs[orbit["Inclination"]] == 1;
+
+
+sphericalOrbitQ[orbit_KerrGeoOrbitFunction] := orbit["e"] == 0;
+
+
+eccentricOrbitQ[orbit_KerrGeoOrbitFunction] := Abs[orbit["Inclination"]] == 1;
+
+
+TeukolskyPointParticleMode[s_Integer, l_Integer, m_Integer, orbit_KerrGeoOrbitFunction, opts:OptionsPattern[]] /; circularOrbitQ[orbit] :=
+  TeukolskyPointParticleMode[s, l, m, 0, 0, orbit, opts]
+
+
+TeukolskyPointParticleMode[s_Integer, l_Integer, m_Integer, k_Integer, orbit_KerrGeoOrbitFunction, opts:OptionsPattern[]] /; sphericalOrbitQ[orbit] :=
+  TeukolskyPointParticleMode[s, l, m, 0, k, orbit, opts]
+
+
+TeukolskyPointParticleMode[s_Integer, l_Integer, m_Integer, n_Integer, orbit_KerrGeoOrbitFunction, opts:OptionsPattern[]] /; eccentricOrbitQ[orbit] :=
+  TeukolskyPointParticleMode[s, l, m, n, orbit, opts]
 
 
 (* ::Section::Closed:: *)


### PR DESCRIPTION
For certain cases there is no need to specify all three mode numbers (m, n, k). For circular orbits, n and k are not required. For spherical orbits n is not required. For eccentric k is not required. This pull request makes it possible to not specify the mode numbers that are not required in those cases. This make is more convenient, but potentially causes confusion as something like ```TeukolskyPointParticleMode[s, l, m, n, orbit]``` and ```TeukolskyPointParticleMode[s, l, m, k, orbit]``` will do different things depending on whether the orbit is spherical or eccentric.