### PR TITLE
S plus/minus 1

### DIFF
--- a/Kernel/ConvolveSource.m
+++ b/Kernel/ConvolveSource.m
@@ -937,6 +937,7 @@ ConvolveSourcePointParticleGeneric[s:-1, n_Integer, k_Integer, R_, SH_, TS_] :=
     Kt = (r0^2 + a^2) \[Omega] - m a;
     \[Rho] = -1/(r0 - I a Cos[\[Theta]0]);
     \[Rho]bar = -1/(r0 + I a Cos[\[Theta]0]);
+    \[CapitalSigma] = (\[Rho] \[Rho]bar)^-1;
       
     An0 = -1/Sqrt[2] \[CapitalDelta]^-1 \[Rho]^3 \[Rho]bar^3 (S0 \[Rho]^-4 \[Rho]bar^-2 L1 + dS0/(\[Rho]^4 \[Rho]bar^2)-(4 I a S0 Sin[\[Theta]0])/(\[Rho]^3 \[Rho]bar^2)+(2 I a S0 Sin[\[Theta]0])/(\[Rho]^4 \[Rho]bar));
     Ambar0 = 1/2 S0 \[Rho]^-1 \[Rho]bar (I Kt/\[CapitalDelta]-2\[Rho]+\[Rho]bar);

--- a/Kernel/ConvolveSource.m
+++ b/Kernel/ConvolveSource.m
@@ -942,8 +942,8 @@ ConvolveSourcePointParticleSpherical[s:-1, k_Integer, R_, SH_, TS_] :=
     \[CapitalSigma] = 1/(\[Rho] \[Rho]bar);
   
     An0 =(dS0+L1 S0+I a S0 \[Rho] Sin[\[Theta]0])/(Sqrt[2] \[CapitalDelta] \[Rho]);
-    Ambar0 =(I S0 (Kt+I \[CapitalDelta] \[Rho]) \[Rho]bar)/(2 \[CapitalDelta] \[Rho]);
-    Ambar1 = (S0 \[Rho]bar)/(2 \[Rho]);
+    Ambar0 =-(I S0 (Kt+I \[CapitalDelta] \[Rho]) \[Rho]bar)/(2 \[CapitalDelta] \[Rho]);
+    Ambar1 = -(S0 \[Rho]bar)/(2 \[Rho]);
     (* Save time by folding the two segments in Subscript[q, \[Theta]]\[Element][0,2\[Pi]] over to Subscript[q, \[Theta]]\[Element][0,\[Pi]] *)
     rcomp = (\[ScriptCapitalE](r0^2+a^2) - a \[ScriptCapitalL] + ur0)/(2\[CapitalSigma]);
     \[Theta]comp = \[Rho] (I Sin[\[Theta]0](a \[ScriptCapitalE] - \[ScriptCapitalL]/Sin[\[Theta]0]^2) + u\[Theta]0)/Sqrt[2];

--- a/Kernel/ConvolveSource.m
+++ b/Kernel/ConvolveSource.m
@@ -22,7 +22,7 @@ BeginPackage["Teukolsky`ConvolveSource`", {"KerrGeodesics`", "KerrGeodesics`Orbi
 Begin["`Private`"];
 
 
-(* ::Section::Closed:: *)
+(* ::Section:: *)
 (*ConvolveSource*)
 
 
@@ -306,7 +306,7 @@ ConvolveSourcePointParticleEccentric[s:-2, n_Integer, R_, SH_, TS_] :=
 ]
 
 
-(* ::Subsection::Closed:: *)
+(* ::Subsection:: *)
 (*s=-2 point particle on a generic orbit*)
 
 
@@ -839,7 +839,7 @@ ConvolveSourcePointParticleGeneric[2, n_Integer, k_Integer, R_, SH_, TS_] :=
 ]
 
 
-(* ::Subsection::Closed:: *)
+(* ::Subsection:: *)
 (*s=\[PlusMinus]1 point particle on a circular orbit*)
 
 
@@ -890,6 +890,93 @@ ConvolveSourcePointParticleCircular[s:(-1|+1), R_, SH_, TS_] :=
   Clear[a, r0, \[Theta], m, \[Omega], \[CapitalDelta], \[CapitalDelta]p, W, A, B, RIn, ROut, dRIn, dROut, dS, S, PIn, POut, dPIn, dPOut];
 
   <| "\[ScriptCapitalI]" -> ZOut, "\[ScriptCapitalH]" -> ZIn |>
+]
+
+
+(* ::Subsection:: *)
+(*s = \[ImplicitPlus]-1 point particle on a generic orbit*)
+
+
+ConvolveSourcePointParticleGeneric[s:-1, n_Integer, k_Integer, R_, SH_, TS_] :=
+ Module[{a, p, \[ScriptCapitalE], \[ScriptCapitalL], rpi, \[Theta]pi, urpi, u\[Theta]pi, \[CapitalUpsilon]t, \[CapitalUpsilon]r, \[CapitalUpsilon]\[Theta], \[CapitalDelta]tr, \[CapitalDelta]t\[Theta], \[CapitalDelta]\[Phi]r, \[CapitalDelta]\[Phi]\[Theta], qt0, qr0, q\[Theta]0, q\[Phi]0, m, \[Omega], \[Lambda], W, rq, \[Theta]q, urq, u\[Theta]q, integrand, integrandIn, integrandUp, \[Alpha]In, \[Alpha]Up, \[Xi], wpIn, wpUp, ZIn, ZUp},
+  a = TS["Orbit"]["a"];
+  p = TS["Orbit"]["p"];
+  {\[ScriptCapitalE], \[ScriptCapitalL]} = TS["Orbit"] /@ {"Energy", "AngularMomentum"};
+  {rpi, \[Theta]pi} = TS["Orbit"]["Trajectory"][[2;;3]];
+  {urpi, u\[Theta]pi} = TS["Orbit"]["FourVelocity"][[2;;3]];
+
+  {\[CapitalUpsilon]t, \[CapitalUpsilon]r, \[CapitalUpsilon]\[Theta]} = {"\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(t\)]\)", "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(r\)]\)", "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Theta]\)]\)"} /. TS["Orbit"]["Frequencies"];
+  {\[CapitalDelta]tr, \[CapitalDelta]t\[Theta], \[CapitalDelta]\[Phi]r, \[CapitalDelta]\[Phi]\[Theta]} = {"\[CapitalDelta]tr", "\[CapitalDelta]t\[Theta]", "\[CapitalDelta]\[Phi]r", "\[CapitalDelta]\[Phi]\[Theta]"} /. TS["Orbit"]["TrajectoryDeltas"];
+  {qt0, qr0, q\[Theta]0, q\[Phi]0} = TS["Orbit"]["InitialPhases"];
+
+  m = R["In"]["m"];
+  \[Omega] = R["In"]["\[Omega]"];
+  \[Lambda] = R["In"]["Eigenvalue"];
+
+  W = 2 I \[Omega] R["In"]["Amplitudes"]["Incidence"];
+
+  rq[qr_] := rpi[(qr-qr0)/\[CapitalUpsilon]r];
+  \[Theta]q[q\[Theta]_] := \[Theta]pi[(q\[Theta]-q\[Theta]0)/\[CapitalUpsilon]\[Theta]];
+
+  (* Mino-time four-velocities *)
+  urq[qr_] := (rpi[(qr-qr0)/\[CapitalUpsilon]r]^2+a^2 Cos[\[Theta]pi[(qr-qr0)/\[CapitalUpsilon]r]]^2) urpi[(qr-qr0)/\[CapitalUpsilon]r];
+  u\[Theta]q[q\[Theta]_] := (rpi[(q\[Theta]-q\[Theta]0)/\[CapitalUpsilon]\[Theta]]^2+a^2 Cos[\[Theta]pi[(q\[Theta]-q\[Theta]0)/\[CapitalUpsilon]\[Theta]]]^2) u\[Theta]pi[(q\[Theta]-q\[Theta]0)/\[CapitalUpsilon]\[Theta]];
+
+  integrand[qr_, q\[Theta]_, RF_]:=
+   Module[{r0, R0, dR0, \[Theta]0, S0, dS0, L1, ur0, u\[Theta]0, rcomp, \[Theta]comp, \[CapitalDelta], Kt, \[Rho], \[Rho]bar, \[CapitalSigma], An0, Ambar0, Ambar1, Cnp1p1, Cmbarp1p1, Cnp1m1, Cmbarp1m1, Cnm1p1, Cmbarm1p1, Cnm1m1,Cmbarm1m1, rphase, \[Theta]phase, res},
+    r0 = rq[qr];
+    R0   = RF[r0];
+    dR0  = RF'[r0];
+      
+    \[Theta]0 = \[Theta]q[q\[Theta]];
+    S0 = SH[\[Theta]0, 0];
+    dS0 = Derivative[1,0][SH][\[Theta]0, 0];
+    L1 = -m/Sin[\[Theta]0] + a \[Omega] Sin[\[Theta]0] + Cos[\[Theta]0]/Sin[\[Theta]0]; 
+  
+    \[CapitalDelta] = r0^2 + a^2 - 2 r0;
+    Kt = (r0^2 + a^2) \[Omega] - m a;
+    \[Rho] = -1/(r0 - I a Cos[\[Theta]0]);
+    \[Rho]bar = -1/(r0 + I a Cos[\[Theta]0]);
+      
+    An0 = -1/Sqrt[2] \[CapitalDelta]^-1 \[Rho]^3 \[Rho]bar^3 (S0 \[Rho]^-4 \[Rho]bar^-2 L1 + dS0/(\[Rho]^4 \[Rho]bar^2)-(4 I a S0 Sin[\[Theta]0])/(\[Rho]^3 \[Rho]bar^2)+(2 I a S0 Sin[\[Theta]0])/(\[Rho]^4 \[Rho]bar));
+    Ambar0 = 1/2 S0 \[Rho]^-1 \[Rho]bar (I Kt/\[CapitalDelta]-2\[Rho]+\[Rho]bar);
+    Ambar1 = (1/2)S0 \[Rho]^-1 \[Rho]bar;
+    
+    (* Save time by folding the four segments in Subscript[q, \[Theta]]\[Element][0,2\[Pi]], Subscript[q, r]\[Element][0,2\[Pi]] over to Subscript[q, \[Theta]]\[Element][0,\[Pi]], Subscript[q, r]\[Element][0,\[Pi]] *)
+    rcomp = (\[ScriptCapitalE](r0^2+a^2) - a \[ScriptCapitalL] + ur0)/(2\[CapitalSigma]);
+    \[Theta]comp = \[Rho] (I Sin[\[Theta]0](a \[ScriptCapitalE] - \[ScriptCapitalL]/Sin[\[Theta]0]^2) + u\[Theta]0)/Sqrt[2];
+    
+    {{{Cnp1p1,Cmbarp1p1}, {Cnp1m1,Cmbarp1m1}},
+      {{Cnm1p1,Cmbarm1p1}, {Cnm1m1,Cmbarm1m1}}} =
+      Table[{rcomp,\[Theta]comp}, {ur0, {urq[qr], urq[2\[Pi]-qr]}}, {u\[Theta]0, {u\[Theta]q[q\[Theta]], u\[Theta]q[2\[Pi]-q\[Theta]]}}];
+    
+    rphase = \[Omega] \[CapitalDelta]tr[qr] - m \[CapitalDelta]\[Phi]r[qr] + n qr;
+    \[Theta]phase = \[Omega] \[CapitalDelta]t\[Theta][q\[Theta]] - m \[CapitalDelta]\[Phi]\[Theta][q\[Theta]] + k q\[Theta];
+    
+    res = ((An0*Cnp1p1 + Ambar0*Cmbarp1p1) R0-(Ambar1*Cmbarp1p1) dR0)Exp[I(rphase+\[Theta]phase)] 
+        + ((An0*Cnp1m1 + Ambar0*Cmbarp1m1) R0-(Ambar1*Cmbarp1m1) dR0)Exp[I(rphase-\[Theta]phase)] 
+        + ((An0*Cnm1p1 + Ambar0*Cmbarm1p1) R0-(Ambar1*Cmbarm1p1) dR0)Exp[-I(rphase-\[Theta]phase)] 
+        + ((An0*Cnm1m1 + Ambar0*Cmbarm1m1) R0-(Ambar1*Cmbarm1m1) dR0)Exp[-I(rphase+\[Theta]phase)];
+    Clear[r0, R0, dR0,  \[Theta]0, S0, dS0, L1, ur0, u\[Theta]0, rcomp, \[Theta]comp, \[CapitalDelta], Kt, \[Rho], \[Rho]bar, \[CapitalSigma], An0, Ambar0, Ambar1, Cnp1p1, Cmbarp1p1, Cnp1m1, Cmbarp1m1, Cnm1p1, Cmbarm1p1, Cnm1m1,Cmbarm1m1, rphase, \[Theta]phase];
+    res
+  ];
+  
+  integrandIn[qr_, q\[Theta]_] := integrand[qr,q\[Theta],R["In"]];
+  integrandUp[qr_, q\[Theta]_] := integrand[qr,q\[Theta],R["Up"]];
+
+  wpIn = Precision[integrandIn[0, 0]];
+  wpUp = Precision[integrandUp[0, 0]];
+
+  \[Alpha]In = 1/(2\[Pi])^2 Quiet[NIntegrate[integrandIn[qr, q\[Theta]], {qr, 0, \[Pi]}, {q\[Theta], 0, \[Pi]}, Method -> {"Trapezoidal", "SymbolicProcessing"->0}, WorkingPrecision -> wpIn], NIntegrate::precw];
+  \[Alpha]Up = 1/(2\[Pi])^2 Quiet[NIntegrate[integrandUp[qr, q\[Theta]], {qr, 0, \[Pi]}, {q\[Theta], 0, \[Pi]}, Method -> {"Trapezoidal", "SymbolicProcessing"->0}, WorkingPrecision -> wpUp], NIntegrate::precw];
+  
+  \[Xi] = m(\[CapitalDelta]\[Phi]r[qr0]+\[CapitalDelta]\[Phi]\[Theta][q\[Theta]0]-q\[Phi]0) - \[Omega](\[CapitalDelta]tr[qr0]+\[CapitalDelta]t\[Theta][q\[Theta]0]-qt0) - k q\[Theta]0 - n qr0;
+
+  ZIn = 8Pi \[Alpha]Up/W/\[CapitalUpsilon]t Exp[I \[Xi]];
+  ZUp = 8Pi \[Alpha]In/W/\[CapitalUpsilon]t Exp[I \[Xi]];
+
+  Clear[a, p, \[ScriptCapitalE], \[ScriptCapitalL], rpi, \[Theta]pi, urpi, u\[Theta]pi, \[CapitalUpsilon]t, \[CapitalUpsilon]r, \[CapitalUpsilon]\[Theta], \[CapitalDelta]tr, \[CapitalDelta]t\[Theta], \[CapitalDelta]\[Phi]r, \[CapitalDelta]\[Phi]\[Theta], qt0, qr0, q\[Theta]0, q\[Phi]0, m, \[Omega], \[Lambda], W, rq, \[Theta]q, urq, u\[Theta]q, integrand, integrandIn, integrandUp, \[Alpha]In, \[Alpha]Up, \[Xi], wpIn, wpUp];
+  <| "\[ScriptCapitalI]" -> ZUp, "\[ScriptCapitalH]" -> ZIn |>
 ]
 
 

--- a/Kernel/ConvolveSource.m
+++ b/Kernel/ConvolveSource.m
@@ -22,7 +22,7 @@ BeginPackage["Teukolsky`ConvolveSource`", {"KerrGeodesics`", "KerrGeodesics`Orbi
 Begin["`Private`"];
 
 
-(* ::Section:: *)
+(* ::Section::Closed:: *)
 (*ConvolveSource*)
 
 
@@ -1226,7 +1226,7 @@ ConvolveSourcePointParticleSpherical[s:1, k_Integer, R_, SH_, TS_] :=
 ]
 
 
-(* ::Subsection:: *)
+(* ::Subsection::Closed:: *)
 (*s=+1 point particle on an eccentric orbit*)
 
 
@@ -1288,7 +1288,6 @@ ConvolveSourcePointParticleEccentric[1, n_Integer, R_, SH_, TS_] :=
         + ((Al0*Clm1 + Am0*Cmm1) R0-(Am1*Cmm1) dR0)Exp[-I rphase];
         
     Clear[r0, R0, dR0, ur0, u\[Theta]0, rcomp, \[Theta]comp, \[CapitalDelta], \[CapitalDelta]p, Kt, \[Rho], \[Rho]bar, rphase, \[Theta]phase];
-    (*Print[res];*)
     res
   ];
   
@@ -1311,7 +1310,7 @@ ConvolveSourcePointParticleEccentric[1, n_Integer, R_, SH_, TS_] :=
 ]
 
 
-(* ::Subsection:: *)
+(* ::Subsection::Closed:: *)
 (*s=+1 point particle on a generic orbit*)
 
 

--- a/Kernel/ConvolveSource.m
+++ b/Kernel/ConvolveSource.m
@@ -306,7 +306,7 @@ ConvolveSourcePointParticleEccentric[s:-2, n_Integer, R_, SH_, TS_] :=
 ]
 
 
-(* ::Subsection:: *)
+(* ::Subsection::Closed:: *)
 (*s=-2 point particle on a generic orbit*)
 
 
@@ -839,7 +839,7 @@ ConvolveSourcePointParticleGeneric[2, n_Integer, k_Integer, R_, SH_, TS_] :=
 ]
 
 
-(* ::Subsection:: *)
+(* ::Subsection::Closed:: *)
 (*s=\[PlusMinus]1 point particle on a circular orbit*)
 
 
@@ -894,10 +894,92 @@ ConvolveSourcePointParticleCircular[s:(-1|+1), R_, SH_, TS_] :=
 
 
 (* ::Subsection:: *)
+(*s=-1 point particle on a spherical orbit*)
+
+
+ConvolveSourcePointParticleSpherical[s:-1, k_Integer, R_, SH_, TS_] :=
+ Module[{a, p, \[ScriptCapitalE], \[ScriptCapitalL], \[Theta]pi, u\[Theta]pi, r0, ur0, \[CapitalDelta], Kt, \[CapitalUpsilon]t, \[CapitalUpsilon]r, \[CapitalUpsilon]\[Theta], \[CapitalDelta]t\[Theta], \[CapitalDelta]\[Phi]\[Theta], qt0, qr0, q\[Theta]0, q\[Phi]0, m, \[Omega], \[Lambda], W, \[Theta]q, u\[Theta]q, RIn, dRIn, d2RIn, RUp, dRUp, d2RUp, integrand, \[Alpha]In, \[Alpha]Up, \[Xi], wpIn, wpUp, ZIn, ZUp},
+  a = TS["Orbit"]["a"];
+  p = TS["Orbit"]["p"];
+  {\[ScriptCapitalE], \[ScriptCapitalL]} = TS["Orbit"] /@ {"Energy", "AngularMomentum"};
+  \[Theta]pi = TS["Orbit"]["Trajectory"][[3]];
+  u\[Theta]pi = TS["Orbit"]["FourVelocity"][[3]];
+
+  {\[CapitalUpsilon]t, \[CapitalUpsilon]\[Theta]} = {"\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(t\)]\)", "\!\(\*SubscriptBox[\(\[CapitalUpsilon]\), \(\[Theta]\)]\)"} /. TS["Orbit"]["Frequencies"];
+  {\[CapitalDelta]t\[Theta], \[CapitalDelta]\[Phi]\[Theta]} = {"\[CapitalDelta]t\[Theta]", "\[CapitalDelta]\[Phi]\[Theta]"} /. TS["Orbit"]["TrajectoryDeltas"];
+  {qt0, qr0, q\[Theta]0, q\[Phi]0} = TS["Orbit"]["InitialPhases"];
+
+  m = R["In"]["m"];
+  \[Omega] = R["In"]["\[Omega]"];
+  \[Lambda] = R["In"]["Eigenvalue"];
+
+  W = 2 I \[Omega] R["In"]["Amplitudes"]["Incidence"];
+
+  r0 = p;
+  \[Theta]q[q\[Theta]_] := \[Theta]pi[(q\[Theta]-q\[Theta]0)/\[CapitalUpsilon]\[Theta]];
+
+  (* Mino-time four-velocities *)
+  ur0 = 0;
+  u\[Theta]q[q\[Theta]_] := (r0^2+a^2 Cos[\[Theta]pi[(q\[Theta]-q\[Theta]0)/\[CapitalUpsilon]\[Theta]]]^2) u\[Theta]pi[(q\[Theta]-q\[Theta]0)/\[CapitalUpsilon]\[Theta]];
+
+  \[CapitalDelta] = r0^2-2r0+a^2;
+  Kt=(r0^2+a^2)\[Omega]-m a;
+
+  RUp = R["Up"][r0];
+  RIn = R["In"][r0];
+  dRUp = R["Up"]'[r0];
+  dRIn = R["In"]'[r0];
+  
+  integrand[q\[Theta]_, {R0_, dR0_}]:=
+   Module[{\[Theta]0, S0, dS0, L1,  u\[Theta]0, rcomp, \[Theta]comp, \[Rho], \[Rho]bar, \[CapitalSigma], An0, Ambar0, Ambar1, Cnp1p1, Cmbarp1p1, Cnp1m1, Cmbarp1m1, \[Theta]phase, res},
+    \[Theta]0 = \[Theta]q[q\[Theta]];
+    S0 = SH[\[Theta]0, 0];
+    dS0 = Derivative[1,0][SH][\[Theta]0, 0];
+    L1 = -m/Sin[\[Theta]0] + a \[Omega] Sin[\[Theta]0] + Cos[\[Theta]0]/Sin[\[Theta]0];
+       
+    \[Rho] = -1/(r0 - I a Cos[\[Theta]0]);
+    \[Rho]bar = -1/(r0 + I a Cos[\[Theta]0]);
+    \[CapitalSigma] = 1/(\[Rho] \[Rho]bar);
+  
+    An0 =(dS0+L1 S0+I a S0 \[Rho] Sin[\[Theta]0])/(Sqrt[2] \[CapitalDelta] \[Rho]);
+    Ambar0 =(I S0 (Kt+I \[CapitalDelta] \[Rho]) \[Rho]bar)/(2 \[CapitalDelta] \[Rho]);
+    Ambar1 = (S0 \[Rho]bar)/(2 \[Rho]);
+    (* Save time by folding the two segments in Subscript[q, \[Theta]]\[Element][0,2\[Pi]] over to Subscript[q, \[Theta]]\[Element][0,\[Pi]] *)
+    rcomp = (\[ScriptCapitalE](r0^2+a^2) - a \[ScriptCapitalL] + ur0)/(2\[CapitalSigma]);
+    \[Theta]comp = \[Rho] (I Sin[\[Theta]0](a \[ScriptCapitalE] - \[ScriptCapitalL]/Sin[\[Theta]0]^2) + u\[Theta]0)/Sqrt[2];
+    
+    {{Cnp1p1,Cmbarp1p1}, {Cnp1m1,Cmbarp1m1}} =
+      Table[{rcomp, \[Theta]comp}, {u\[Theta]0, {u\[Theta]q[q\[Theta]], u\[Theta]q[2\[Pi]-q\[Theta]]}}];
+    
+    \[Theta]phase = \[Omega] \[CapitalDelta]t\[Theta][q\[Theta]] - m \[CapitalDelta]\[Phi]\[Theta][q\[Theta]] + k q\[Theta];
+    
+    res = ((An0*Cnp1p1 + Ambar0*Cmbarp1p1) R0-(Ambar1*Cmbarp1p1) dR0)Exp[I \[Theta]phase] 
+        + ((An0*Cnp1m1 + Ambar0*Cmbarp1m1) R0-(Ambar1*Cmbarp1m1) dR0)Exp[-I \[Theta]phase];
+    Clear[\[Theta]0, S0, dS0, L1, u\[Theta]0, rcomp, \[Theta]comp, \[Rho], \[Rho]bar, \[CapitalSigma], An0, Ambar0, Ambar1, Cnp1p1, Cmbarp1p1, Cnp1m1, Cmbarp1m1, \[Theta]phase];
+    res  
+  ];
+
+  wpIn = Precision[integrand[0, {RIn, dRIn}]];
+  wpUp = Precision[integrand[0, {RUp, dRUp}]];
+
+  \[Alpha]In = 1/(2\[Pi]) Quiet[NIntegrate[integrand[q\[Theta], {RIn, dRIn}], {q\[Theta], 0, \[Pi]}, Method -> {"Trapezoidal", "SymbolicProcessing"->0}, WorkingPrecision -> wpIn], NIntegrate::precw];
+  \[Alpha]Up = 1/(2\[Pi]) Quiet[NIntegrate[integrand[q\[Theta], {RUp, dRUp}], {q\[Theta], 0, \[Pi]}, Method -> {"Trapezoidal", "SymbolicProcessing"->0}, WorkingPrecision -> wpUp], NIntegrate::precw];
+  
+  \[Xi] = m(\[CapitalDelta]\[Phi]\[Theta][q\[Theta]0]-q\[Phi]0) - \[Omega](\[CapitalDelta]t\[Theta][q\[Theta]0]-qt0) - k q\[Theta]0;
+
+  ZIn = 8Pi \[Alpha]Up/W/\[CapitalUpsilon]t Exp[I \[Xi]];
+  ZUp = 8Pi \[Alpha]In/W/\[CapitalUpsilon]t Exp[I \[Xi]];
+
+  Clear[a, p, \[ScriptCapitalE], \[ScriptCapitalL], \[Theta]pi, u\[Theta]pi, r0, ur0, \[CapitalDelta], Kt, \[CapitalUpsilon]t, \[CapitalUpsilon]r, \[CapitalUpsilon]\[Theta], \[CapitalDelta]t\[Theta], \[CapitalDelta]\[Phi]\[Theta], qt0, qr0, q\[Theta]0, q\[Phi]0, m, \[Omega], \[Lambda], W, \[Theta]q, u\[Theta]q, RIn, dRIn, RUp, dRUp, integrand, \[Alpha]In, \[Alpha]Up, \[Xi], wpIn, wpUp];
+  <| "\[ScriptCapitalI]" -> ZUp, "\[ScriptCapitalH]" -> ZIn |>
+]
+
+
+(* ::Subsection::Closed:: *)
 (*s = \[ImplicitPlus]-1 point particle on a generic orbit*)
 
 
-ConvolveSourcePointParticleGeneric[s:-1, n_Integer, k_Integer, R_, SH_, TS_] :=
+ConvolveSourcePointParticleGeneric[-1, n_Integer, k_Integer, R_, SH_, TS_] :=
  Module[{a, p, \[ScriptCapitalE], \[ScriptCapitalL], rpi, \[Theta]pi, urpi, u\[Theta]pi, \[CapitalUpsilon]t, \[CapitalUpsilon]r, \[CapitalUpsilon]\[Theta], \[CapitalDelta]tr, \[CapitalDelta]t\[Theta], \[CapitalDelta]\[Phi]r, \[CapitalDelta]\[Phi]\[Theta], qt0, qr0, q\[Theta]0, q\[Phi]0, m, \[Omega], \[Lambda], W, rq, \[Theta]q, urq, u\[Theta]q, integrand, integrandIn, integrandUp, \[Alpha]In, \[Alpha]Up, \[Xi], wpIn, wpUp, ZIn, ZUp},
   a = TS["Orbit"]["a"];
   p = TS["Orbit"]["p"];

--- a/Kernel/TeukolskyMode.m
+++ b/Kernel/TeukolskyMode.m
@@ -122,8 +122,8 @@ TeukolskyPointParticleMode[s_Integer, l_Integer, m_Integer, n_Integer, k_Integer
   assoc = <| "s" -> s, 
 		     "l" -> l,
 		     "m" -> m,
-		     "n"->n,
-		     "k"->k,
+		     "n" -> n,
+		     "k" -> k,
 		     "a" -> a,
   		   "\[Omega]" -> \[Omega],
 		     "Eigenvalue" -> R["In"]["Eigenvalue"],
@@ -263,7 +263,7 @@ Derivative[n_][TeukolskyMode[assoc_]["ExtendedHomogeneous" -> "\[ScriptCapitalI]
 (*Fluxes*)
 
 
-(* ::Subsection::Closed:: *)
+(* ::Subsection:: *)
 (*Energy Flux*)
 
 

--- a/Kernel/TeukolskyMode.m
+++ b/Kernel/TeukolskyMode.m
@@ -59,7 +59,7 @@ TeukolskyPointParticleMode::noret = "This package does not compute the retarded 
 Begin["`Private`"];
 
 
-(* ::Section:: *)
+(* ::Section::Closed:: *)
 (*TeukolskyPointParticleMode*)
 
 
@@ -72,15 +72,7 @@ Options[TeukolskyPointParticleMode] = {"Domain" -> Automatic};
 
 TeukolskyPointParticleMode[s_Integer, l_Integer, m_Integer, n_Integer, k_Integer, orbit_KerrGeoOrbitFunction, opts:OptionsPattern[]] /; AllTrue[orbit["Frequencies"], InexactNumberQ] :=
  Module[{source, assoc, domain, Ruser, R, S, \[Omega], \[CapitalOmega]r, \[CapitalOmega]\[Phi], \[CapitalOmega]\[Theta], Z, \[Lambda], rmin, rmax, a, p, e, x},
-  {a, p, e, x} = orbit /@ {"a", "p", "e", "Inclination"};
-
-  (*If[!MemberQ[{-2, -1, 0, 1, 2}, s] ||
-     (Abs[s] == 1 && {e, x} != {0, 1}) ||
-     (s == +2 && {a, e, x} != {0, 0, 1}),
-    Message[TeukolskyPointParticleMode::params, s, e, x];
-    Return[$Failed];
-  ];*)
-  
+  {a, p, e, x} = orbit /@ {"a", "p", "e", "Inclination"};  
 
   If[{e, Abs[x]} == {0, 1} && (n != 0 || k != 0),
     Message[TeukolskyPointParticleMode::mode, n, k, "circular"];
@@ -259,11 +251,11 @@ Derivative[n_][TeukolskyMode[assoc_]["ExtendedHomogeneous" -> "\[ScriptCapitalI]
   assoc["Amplitudes"]["\[ScriptCapitalI]"]Derivative[n][assoc["RadialFunctions"]["Up"]][r];
 
 
-(* ::Section:: *)
+(* ::Section::Closed:: *)
 (*Fluxes*)
 
 
-(* ::Subsection:: *)
+(* ::Subsection::Closed:: *)
 (*Energy Flux*)
 
 
@@ -324,7 +316,7 @@ EnergyFlux[mode_TeukolskyMode] :=
 AngularMomentumFlux[mode_TeukolskyMode] := If[mode["\[Omega]"]!=0,EnergyFlux[mode] mode["m"]/mode["\[Omega]"],0];
 
 
-(* ::Section:: *)
+(* ::Section::Closed:: *)
 (*End Package*)
 
 
@@ -335,7 +327,7 @@ AngularMomentumFlux[mode_TeukolskyMode] := If[mode["\[Omega]"]!=0,EnergyFlux[mod
 SetAttributes[{TeukolskyMode, TeukolskyPointParticleMode}, {Protected, ReadProtected}];
 
 
-(* ::Subsection:: *)
+(* ::Subsection::Closed:: *)
 (*End*)
 
 

--- a/Kernel/TeukolskyMode.m
+++ b/Kernel/TeukolskyMode.m
@@ -59,7 +59,7 @@ TeukolskyPointParticleMode::noret = "This package does not compute the retarded 
 Begin["`Private`"];
 
 
-(* ::Section::Closed:: *)
+(* ::Section:: *)
 (*TeukolskyPointParticleMode*)
 
 
@@ -80,11 +80,7 @@ TeukolskyPointParticleMode[s_Integer, l_Integer, m_Integer, n_Integer, k_Integer
     Message[TeukolskyPointParticleMode::params, s, e, x];
     Return[$Failed];
   ];*)
-  If[!MemberQ[{-2, -1, 0, 1, 2}, s] ||
-     (Abs[s] == 1 && {e, x} != {0, 1}),
-    Message[TeukolskyPointParticleMode::params, s, e, x];
-    Return[$Failed];
-  ];
+  
 
   If[{e, Abs[x]} == {0, 1} && (n != 0 || k != 0),
     Message[TeukolskyPointParticleMode::mode, n, k, "circular"];

--- a/Kernel/TeukolskyMode.m
+++ b/Kernel/TeukolskyMode.m
@@ -83,6 +83,10 @@ TeukolskyPointParticleMode[s_Integer, l_Integer, m_Integer, n_Integer, k_Integer
   If[Abs[x] == 1 && k != 0,
     Message[TeukolskyPointParticleMode::mode, n, k, "eccentric"];
     Return[$Failed]];
+  If[!MemberQ[{-2,-1,0,1,2},s], 
+    Message[TeukolskyPointParticleMode::params,s];
+    Return[$Failed];
+    ];
 
   (*{\[CapitalOmega]r, \[CapitalOmega]\[Theta], \[CapitalOmega]\[Phi]} = orbit["Frequencies"];*) (*This gives Mino frequencies, need BL frequencies*)
   {\[CapitalOmega]r, \[CapitalOmega]\[Theta], \[CapitalOmega]\[Phi]} = {"\!\(\*SubscriptBox[\(\[CapitalOmega]\), \(r\)]\)","\!\(\*SubscriptBox[\(\[CapitalOmega]\), \(\[Theta]\)]\)","\!\(\*SubscriptBox[\(\[CapitalOmega]\), \(\[Phi]\)]\)"}/.KerrGeoFrequencies[orbit["a"], orbit["p"], orbit["e"], orbit["Inclination"]];
@@ -333,6 +337,3 @@ SetAttributes[{TeukolskyMode, TeukolskyPointParticleMode}, {Protected, ReadProte
 
 End[];
 EndPackage[];
-
-
-

--- a/Kernel/TeukolskyMode.m
+++ b/Kernel/TeukolskyMode.m
@@ -259,7 +259,7 @@ Derivative[n_][TeukolskyMode[assoc_]["ExtendedHomogeneous" -> "\[ScriptCapitalI]
   assoc["Amplitudes"]["\[ScriptCapitalI]"]Derivative[n][assoc["RadialFunctions"]["Up"]][r];
 
 
-(* ::Section::Closed:: *)
+(* ::Section:: *)
 (*Fluxes*)
 
 
@@ -280,9 +280,22 @@ EnergyFlux[mode_TeukolskyMode] :=
   rh = M + Sqrt[M^2-a^2];
   \[CapitalOmega]h = a/(2 M rh);
   \[Kappa] = \[Omega] - m \[CapitalOmega]h;
-  \[Epsilon] = Sqrt[M^2-a^2]/(4 M rh);
+  \[Epsilon] = Sqrt[M^2-a^2]/(4 M rh);  	
 
-  FluxInf = Abs[Z["\[ScriptCapitalI]"]]^2 \[Omega]^(2(1-Abs[s]))/(4 \[Pi]);
+  FluxInf = 
+  Switch[s,
+  -2, Abs[Z["\[ScriptCapitalI]"]]^2 \[Omega]^(2(1-Abs[s]))/(4 \[Pi]),
+  -1, Abs[Z["\[ScriptCapitalI]"]]^2 \[Omega]^(2(1-Abs[s]))/(4 \[Pi]),
+  0, Abs[Z["\[ScriptCapitalI]"]]^2 \[Omega]^(2(1-Abs[s]))/(4 \[Pi]),
+  1, AbsCSq = (\[Lambda]+2)^2+ 4 a \[Omega](m-a \[Omega]);
+  (4 \[Omega]^4 Abs[Z["\[ScriptCapitalI]"]]^2)/(AbsCSq) \[Omega]^(2(1-Abs[s]))/(4 \[Pi]),
+  2, AbsCSq = (4+\[Lambda])^2 (6+\[Lambda])^2+144 M^2 \[Omega]^2+8 a (4+\[Lambda]) (-4+5 (6+\[Lambda])) \[Omega] (m-a \[Omega])+48 a^2 \[Omega]^2 (2 (4+\[Lambda])+3 (m-a \[Omega])^2);
+  (16 \[Omega]^8 Abs[Z["\[ScriptCapitalI]"]]^2)/(AbsCSq) \[Omega]^(2(1-Abs[s]))/(4 \[Pi])
+  ];
+                
+  
+  
+  (*Abs[Z["\[ScriptCapitalI]"]]^2 \[Omega]^(2(1-Abs[s]))/(4 \[Pi]);*)
   FluxHor = Switch[s,
 			-2,
 			  AbsCSq = ((\[Lambda]+2)^2 + 4 a m \[Omega] - 4a^2 \[Omega]^2)(\[Lambda]^2+36 m a \[Omega] - 36 a^2 \[Omega]^2) + (2\[Lambda]+3)(96 a^2 \[Omega]^2 - 48 m a \[Omega]) + 144 \[Omega]^2 (M^2-a^2);
@@ -293,7 +306,11 @@ EnergyFlux[mode_TeukolskyMode] :=
 			  \[Omega] Abs[Z["\[ScriptCapitalH]"]]^2 (2 M rh \[Kappa]) 4 ((2 M rh \[Kappa])^2+(M^2-a^2))/ (p \[Pi]),
 			0,
 			  (* The rh^2 factor vs arXiv:1003.1860 Eq. (55) is needed as \[Psi] = r R*)
-			  1/(2 \[Pi] rh) \[Omega](\[Omega]-m \[CapitalOmega]h) Abs[Z["\[ScriptCapitalH]"]]^2*rh^2
+			  1/(2 \[Pi] rh) \[Omega](\[Omega]-m \[CapitalOmega]h) Abs[Z["\[ScriptCapitalH]"]]^2*rh^2,
+			 1,
+			 (\[Omega] Abs[Z["\[ScriptCapitalH]"]]^2)/(32 \[Pi] \[Kappa] rh),
+			 2,
+			  (\[Omega] Abs[Z["\[ScriptCapitalH]"]]^2)/(512 \[Pi] rh^3 \[Kappa] (\[Kappa]^2+4 \[Epsilon]^2))
 			];
 
   <| "\[ScriptCapitalI]" -> FluxInf, "\[ScriptCapitalH]" -> FluxHor |>
@@ -307,7 +324,7 @@ EnergyFlux[mode_TeukolskyMode] :=
 AngularMomentumFlux[mode_TeukolskyMode] := If[mode["\[Omega]"]!=0,EnergyFlux[mode] mode["m"]/mode["\[Omega]"],0];
 
 
-(* ::Section::Closed:: *)
+(* ::Section:: *)
 (*End Package*)
 
 
@@ -318,9 +335,12 @@ AngularMomentumFlux[mode_TeukolskyMode] := If[mode["\[Omega]"]!=0,EnergyFlux[mod
 SetAttributes[{TeukolskyMode, TeukolskyPointParticleMode}, {Protected, ReadProtected}];
 
 
-(* ::Subsection::Closed:: *)
+(* ::Subsection:: *)
 (*End*)
 
 
 End[];
 EndPackage[];
+
+
+

--- a/Kernel/TeukolskySource.m
+++ b/Kernel/TeukolskySource.m
@@ -26,7 +26,7 @@ BeginPackage["Teukolsky`TeukolskySource`", {"KerrGeodesics`", "KerrGeodesics`Orb
 Begin["`Private`"];
 
 
-(* ::Section::Closed:: *)
+(* ::Section:: *)
 (*TeukolskyPointParticleSource*)
 
 
@@ -73,7 +73,10 @@ TeukolskyPointParticleSource[s:(-1|+1), orbit_] := Module[{assoc, a, r0, E0, \[C
          |>;
 
   TeukolskySourceObject[assoc]
-]
+](*/;(orbit[e]==0 && Abs[orbit["Inclination"]]==1);
+*)
+(*TeukolskyPointParticleSource[s:(-1|+1), orbit_] :=
+  TeukolskySourceObject[<|"s" -> s, "SourceType" -> "PointParticle", "Orbit" -> orbit|>];*)
 
 
 TeukolskySourceObject[assoc_][string_] := assoc[string]

--- a/Kernel/TeukolskySource.m
+++ b/Kernel/TeukolskySource.m
@@ -26,7 +26,7 @@ BeginPackage["Teukolsky`TeukolskySource`", {"KerrGeodesics`", "KerrGeodesics`Orb
 Begin["`Private`"];
 
 
-(* ::Section:: *)
+(* ::Section::Closed:: *)
 (*TeukolskyPointParticleSource*)
 
 

--- a/Kernel/TeukolskySource.m
+++ b/Kernel/TeukolskySource.m
@@ -26,7 +26,7 @@ BeginPackage["Teukolsky`TeukolskySource`", {"KerrGeodesics`", "KerrGeodesics`Orb
 Begin["`Private`"];
 
 
-(* ::Section::Closed:: *)
+(* ::Section:: *)
 (*TeukolskyPointParticleSource*)
 
 
@@ -73,10 +73,7 @@ TeukolskyPointParticleSource[s:(-1|+1), orbit_] := Module[{assoc, a, r0, E0, \[C
          |>;
 
   TeukolskySourceObject[assoc]
-](*/;(orbit[e]==0 && Abs[orbit["Inclination"]]==1);
-*)
-(*TeukolskyPointParticleSource[s:(-1|+1), orbit_] :=
-  TeukolskySourceObject[<|"s" -> s, "SourceType" -> "PointParticle", "Orbit" -> orbit|>];*)
+]
 
 
 TeukolskySourceObject[assoc_][string_] := assoc[string]


### PR DESCRIPTION
Added support for s = plus/minus 1 for generic orbits.
-Checked values against previously implemented circular case.
-Checked values were consistent via Teukolsky-Starobinsky identities.

Also added fluxes for s = 1,2. Now users can get fluxes by using TeukolskyPointParticleMode with any value of s.
-Values calculated from s=1, 2 amplitudes consistent with s = -1, -2 values.